### PR TITLE
added support for a callback function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 mysound.*
 test.mp3
 .venv
+.idea
 __pycache__
 test.py
 .vscode

--- a/PySoundSphere/main.py
+++ b/PySoundSphere/main.py
@@ -7,6 +7,7 @@ class AudioPlayer:
     def __init__(self, playback_backend, *, debug_allow_multiple_playbacks: bool = False) -> None:
         self._debug_allow_multiple_playbacks = debug_allow_multiple_playbacks
         self._playback_backend = load_backend(playback_backend)
+        self._callback_function = None
         self._file_path = None
         self._is_paused = False
         self._start_time = 0
@@ -54,19 +55,9 @@ class AudioPlayer:
         Monitor the playback status and trigger a callback when the song finishes.
         """
         while self._playback_backend.get_busy() or self._is_paused:
-            print(self._playback_backend.get_busy())
-            print(self._is_paused)
-            time.sleep(0.5)
-            print("a")
-        print(self._playback_backend.get_busy())
-        print(self._is_paused)
-        self._on_finish()
-
-    def _on_finish(self):
-        """
-        Callback function to be executed when the song finishes.
-        """
-        print("Song finished playing!")
+            time.sleep(0.1)
+        if self._callback_function is not None:
+            self._callback_function()
 
     def pause(self) -> None:
         """
@@ -86,6 +77,12 @@ class AudioPlayer:
             self._playback_backend.stop()
             self._is_paused = False
             self._pause_time = 0
+
+    def set_callback_function(self, function = None) -> None:
+        """
+        Sets the callback function.
+        """
+        self._callback_function = function
 
     @property
     def position(self) -> float:

--- a/PySoundSphere/main.py
+++ b/PySoundSphere/main.py
@@ -1,4 +1,5 @@
 from .playback_backend.backend_loader import load_backend
+import threading
 import time
 import os
 
@@ -38,6 +39,34 @@ class AudioPlayer:
             self._playback_backend.load(self._file_path)
             self._playback_backend.play()
             self._start_time = time.time()
+            self._start_monitoring()
+
+    def _start_monitoring(self):
+        """
+        Start a separate thread to monitor the playback status.
+        """
+        self._monitor_thread = threading.Thread(target=self._monitor_playback)
+        self._monitor_thread.daemon = True
+        self._monitor_thread.start()
+
+    def _monitor_playback(self):
+        """
+        Monitor the playback status and trigger a callback when the song finishes.
+        """
+        while self._playback_backend.get_busy() or self._is_paused:
+            print(self._playback_backend.get_busy())
+            print(self._is_paused)
+            time.sleep(0.5)
+            print("a")
+        print(self._playback_backend.get_busy())
+        print(self._is_paused)
+        self._on_finish()
+
+    def _on_finish(self):
+        """
+        Callback function to be executed when the song finishes.
+        """
+        print("Song finished playing!")
 
     def pause(self) -> None:
         """

--- a/PySoundSphere/playback_backend/sounddevice_backend.py
+++ b/PySoundSphere/playback_backend/sounddevice_backend.py
@@ -83,6 +83,7 @@ class SounddeviceBackend:
             if len(self._data) < frames:
                 outdata[:len(self._data)] = self._volume * self._data
                 outdata[len(self._data):] = 0
+                self._is_busy = False
             else:
                 outdata[:] = self._volume * self._data[:frames]
                 self._data = self._data[frames:]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,3 +116,16 @@ player.stop()
     new_volume = 0.25
     player.volume = new_volume
     ```
+
+## Callback function
+
+A callback function is a function that gets executed once the current audio file finished playing.
+```python title="Set a callback function"
+import PySoundSphere
+...
+def on_audio_finished():
+    # Your logic goes here
+    print("Done!")
+    
+player.set_callback_function(on_audio_finished)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "PySoundSphere"
 description = "Play Audio Using Python"
-version = "0.0.2"
+version = "0.0.3"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [


### PR DESCRIPTION
- using `set_callback_function()` a function can now be set to run once the current audio finished playing
  - compatible with all backends
- `get_busy()` now behaves the same across all backends